### PR TITLE
fix to_string

### DIFF
--- a/Kepler-RoboVetter-DR25.cpp
+++ b/Kepler-RoboVetter-DR25.cpp
@@ -36,6 +36,7 @@
 #include <fstream>
 #include <vector>
 #include <random>
+#include <sstream>
 
 using namespace std;
 
@@ -264,6 +265,13 @@ struct datastruct  // Struct that holds all the data for each individual TCE
 vector <datastruct> data, dataorig;  // Use of vector allows for dynamic memory allocation
 int n;  // Global counting integer only used to loop through TCEs in the data vector
 
+template < typename T >
+std::string to_string( const T& n )
+{
+        std::ostringstream stm ;
+        stm << n ;
+        return stm.str() ;
+};
 
 // The main function where inputs are taken, the Robovetter is run, the Robovetter is re-run through the Monte Carlo to compute scores, and the result file is outputted
 int main (int argc, char* argv[])

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The DR25 Robovetter code is provided, along with the necessary input files that 
 
 ### Prerequisites
 
-The code is written in C++11 and only requires the standard C++ library (specifically, the required libraries are iomanip, iostream, fstream, vector, and random). It has been tested on Linux and Mac to work with:
+The code is written in C++11 and only requires the standard C++ library (specifically, the required libraries are iomanip, iostream, fstream, vector, sstream and random). It has been tested on Linux and Mac to work with:
   - The g++ complier (Minimum version 4.7.2 tested - earlier versions unlikely to work.)
   - The clang++ compiler (Versions 3.4 and 3.5 tested. Version 3.3 may work, but untested. Earlier than 3.3 will not work.)
   - The Intel icpc compiler (Version 17 tested. Earlier versions as far back as 11 very likely to work, but untested.)


### PR DESCRIPTION
In MinGW compiler this was not implemented.
I tried to make a `to_string` which can be used on such compilers. For Compilers that support `to_string()`, this custom implementation will shadow the `std::to_string()`. With this we need one more header `sstream`